### PR TITLE
Fixed project conflict

### DIFF
--- a/agent/pyproject.toml
+++ b/agent/pyproject.toml
@@ -5,10 +5,6 @@ description = "Starter"
 authors = ["Ariel Weinberger <weinberger.ariel@gmail.com>"]
 license = "MIT"
 
-[project]
-name = "greeter"
-version = "0.0.1"
-
 [build-system]
 requires = ["setuptools >= 61.0"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
The conflict hindered the ability to `poetry install` so it had to be fixed. The warning was:

```
Warning: 'demo' is an entry point defined in pyproject.toml, but it's not installed as a script. You may get improper sys.argv[0].

The support to run uninstalled scripts will be removed in a future release.

Run poetry install to resolve and get rid of this message.
```

After removing the conflicting entry in the toml file it is now working as intended.

Keep up the good work!